### PR TITLE
fix: adjust negative values bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /lib
 blast_attack
 tags
+cmake-build-*
+.idea

--- a/src/player.h
+++ b/src/player.h
@@ -35,8 +35,8 @@
 #include <stdint.h>
 
 typedef struct player {
-  uint16_t x;
-  uint16_t y;
+  int16_t x;
+  int16_t y;
   uint16_t width;
   uint16_t height;
   uint16_t speed;


### PR DESCRIPTION
adjust a bug when a number would go to a negative, it change to MAX_VALUE instead because "uint16_t" is unasigned.