### PR TITLE
Introduce hitbox object for collision logic

### DIFF
--- a/src/hitbox.c
+++ b/src/hitbox.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Johnny Richard
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hitbox.h"
+
+#include <SDL.h>
+#include <assert.h>
+
+void
+hitbox_draw(hitbox_t* hitbox, SDL_Renderer* renderer)
+{
+  SDL_Rect rect = {
+    .x = hitbox->x, .y = hitbox->y, .w = hitbox->width, .h = hitbox->height
+  };
+
+  SDL_SetRenderDrawColor(renderer, 0xFF, 0, 0, 1);
+  SDL_RenderFillRect(renderer, &rect);
+}

--- a/src/hitbox.h
+++ b/src/hitbox.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Johnny Richard
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef HITBOX_H
+#define HITBOX_H
+
+#include <SDL.h>
+
+#include <stdint.h>
+
+typedef struct hitbox
+{
+  int16_t x;
+  int16_t y;
+  uint16_t width;
+  uint16_t height;
+} hitbox_t;
+
+// FIXME: This draw has to be a debug feature, in the feature we want to avoid
+//        calling this feature directly.
+void
+hitbox_draw(hitbox_t* hitbox, SDL_Renderer* renderer);
+
+#endif /* HITBOX_H */

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 
 #include "controller.h"
+#include "hitbox.h"
 #include "player.h"
 #include "screen.h"
 
@@ -64,6 +65,11 @@ main(int argc, char* args[])
   player_init(&player);
 
   SDL_Renderer* renderer = screen.renderer;
+  hitbox_t hitbox = { .x = screen.width / 2 - 50,
+                      .y = screen.height / 2 - 50,
+                      .width = 100,
+                      .height = 100 };
+
   while (!quit) {
 
     screen_reset(&screen);
@@ -82,6 +88,7 @@ main(int argc, char* args[])
 
     player_update(&player, &ctrl, screen.width, screen.height);
     player_draw(&player, renderer);
+    hitbox_draw(&hitbox, renderer);
 
     SDL_RenderPresent(renderer);
 


### PR DESCRIPTION
The hitbox object is an attempt of creating an object which delimit
boundaries for players and enemies collision, it the future it can be
used to verify if a player has been collided to a object on the map.
Signed-off-by: Johnny Richard <johnny@johnnyrichard.com>

---

I'm not sure if we should call it **hitbox** or something else to make the
intention clear. I'm open for suggestions.

[v2](https://github.com/fabiomaciel/blast-attack/compare/67812f28ddbe0339a89bcbd0c729df388fc90db1..31f5e8ab7c525e946c258d7e2f3b27b14756363e):
 - Rename box to hitbox 