### PR TITLE
Add checkstyle config and reformat code base

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,192 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Mozilla
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,19 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - 'src'
+          - 'test'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.9.0
+      with:
+        clang-format-version: '14'
+        check-path: ${{ matrix.path }}
+        fallback-style: 'Mozilla'

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ test: lib/libmunit.so $(BUILD_DIR) $(TESTS)
 lib/libmunit.so: $(LIB_DIR) third_party/munit/munit.c
 	$(CC) -Wall -fpic -c third_party/munit/munit.c -shared -o lib/libmunit.so
 
+checkstyle:
+	clang-format -dry-run -Werror */**.c */**.h
+
 clean:
 	@rm -rf $(BUILD_DIR)
 	@rm -rf $(LIB_DIR)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ $ git clone --recursive git@github.com:fabiomaciel/blast-attack.git
 - make
 - SDL2
 - pkg-config
+- clang-format (optional)
 
 ## Contribute
 

--- a/src/controller.c
+++ b/src/controller.c
@@ -5,8 +5,8 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
@@ -18,79 +18,78 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <SDL.h>
 #include "controller.h"
-
+#include <SDL.h>
 
 void
-controller_update(controller_t *self,
-                  SDL_Event    *event)
+controller_update(controller_t* self, SDL_Event* event)
 {
   if (event->type == SDL_KEYDOWN) {
     switch (event->key.keysym.sym) {
-    case SDLK_UP:
-      self->pressed_buttons |= BTN_UP;
-      break;
-    case SDLK_DOWN:
-      self->pressed_buttons |= BTN_DOWN;
-      break;
-    case SDLK_LEFT:
-      self->pressed_buttons |= BTN_LEFT;
-      break;
-    case SDLK_RIGHT:
-      self->pressed_buttons |= BTN_RIGHT;
-      break;
+      case SDLK_UP:
+        self->pressed_buttons |= BTN_UP;
+        break;
+      case SDLK_DOWN:
+        self->pressed_buttons |= BTN_DOWN;
+        break;
+      case SDLK_LEFT:
+        self->pressed_buttons |= BTN_LEFT;
+        break;
+      case SDLK_RIGHT:
+        self->pressed_buttons |= BTN_RIGHT;
+        break;
     }
   }
 
   if (event->type == SDL_KEYUP) {
     switch (event->key.keysym.sym) {
-    case SDLK_UP:
-      self->pressed_buttons ^= BTN_UP;
-      break;
-    case SDLK_DOWN:
-      self->pressed_buttons ^= BTN_DOWN;
-      break;
-    case SDLK_LEFT:
-      self->pressed_buttons ^= BTN_LEFT;
-      break;
-    case SDLK_RIGHT:
-      self->pressed_buttons ^= BTN_RIGHT;
-      break;
+      case SDLK_UP:
+        self->pressed_buttons ^= BTN_UP;
+        break;
+      case SDLK_DOWN:
+        self->pressed_buttons ^= BTN_DOWN;
+        break;
+      case SDLK_LEFT:
+        self->pressed_buttons ^= BTN_LEFT;
+        break;
+      case SDLK_RIGHT:
+        self->pressed_buttons ^= BTN_RIGHT;
+        break;
     }
   }
 }
 
 bool
-controller_is_up_pressed(controller_t *self)
+controller_is_up_pressed(controller_t* self)
 {
   return self->pressed_buttons & BTN_UP;
 }
 
 bool
-controller_is_down_pressed(controller_t *self)
+controller_is_down_pressed(controller_t* self)
 {
   return self->pressed_buttons & BTN_DOWN;
 }
 
 bool
-controller_is_right_pressed(controller_t *self)
+controller_is_right_pressed(controller_t* self)
 {
   return self->pressed_buttons & BTN_RIGHT;
 }
 
 bool
-controller_is_left_pressed(controller_t *self)
+controller_is_left_pressed(controller_t* self)
 {
   return self->pressed_buttons & BTN_LEFT;
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -5,8 +5,8 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
@@ -18,14 +18,15 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef CONTROLLER_H
@@ -35,23 +36,29 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-enum btn_t {
-  BTN_UP    = 1 << 0,
-  BTN_DOWN  = 1 << 1,
+enum btn_t
+{
+  BTN_UP = 1 << 0,
+  BTN_DOWN = 1 << 1,
   BTN_RIGHT = 1 << 2,
-  BTN_LEFT  = 1 << 3
+  BTN_LEFT = 1 << 3
 };
 
-typedef struct controller_t {
+typedef struct controller_t
+{
   uint8_t pressed_buttons;
 } controller_t;
 
-void controller_update(controller_t *self,
-                       SDL_Event    *event);
+void
+controller_update(controller_t* self, SDL_Event* event);
 
-bool controller_is_up_pressed(controller_t *self);
-bool controller_is_down_pressed(controller_t *self);
-bool controller_is_right_pressed(controller_t *self);
-bool controller_is_left_pressed(controller_t *self);
+bool
+controller_is_up_pressed(controller_t* self);
+bool
+controller_is_down_pressed(controller_t* self);
+bool
+controller_is_right_pressed(controller_t* self);
+bool
+controller_is_left_pressed(controller_t* self);
 
 #endif /* CONTROLLER_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,72 +1,69 @@
 /*
-* Copyright (c) 2021, Johnny Richard
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2021, Johnny Richard
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
+#include <SDL.h>
+#include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <SDL.h>
 
 #include "controller.h"
 #include "player.h"
 #include "screen.h"
 
 int
-main (int   argc,
-      char *args[])
+main(int argc, char* args[])
 {
 
   if (SDL_Init(SDL_INIT_VIDEO) < 0) {
     fprintf(
-        stderr,
-        "SDL could not be initialized! SDL_Error: %s\n",
-        SDL_GetError()
-    );
+      stderr, "SDL could not be initialized! SDL_Error: %s\n", SDL_GetError());
     return EXIT_FAILURE;
   }
 
   screen_t screen;
 
-  if(screen_init(&screen) == false){
+  if (screen_init(&screen) == false) {
     return EXIT_FAILURE;
   }
 
   SDL_Rect bg_rect = { .x = 0, .y = 0, .w = screen.width, .h = screen.height };
 
   bool quit = false;
-  controller_t ctrl = {0};
+  controller_t ctrl = { 0 };
 
   player_t player;
   player_init(&player);
 
-  SDL_Renderer *renderer = screen.renderer;
+  SDL_Renderer* renderer = screen.renderer;
   while (!quit) {
 
     screen_reset(&screen);
@@ -90,7 +87,8 @@ main (int   argc,
 
     uint64_t end = SDL_GetPerformanceCounter();
 
-    float elapsedMS = (end - start) / (float)SDL_GetPerformanceFrequency() * 1000.0f;
+    float elapsedMS =
+      (end - start) / (float)SDL_GetPerformanceFrequency() * 1000.0f;
     SDL_Delay(floor(16.666f - elapsedMS));
   }
 

--- a/src/player.c
+++ b/src/player.c
@@ -1,40 +1,41 @@
 /*
-* Copyright (c) 2021, Johnny Richard
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2021, Johnny Richard
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "player.h"
 
-#include <assert.h>
 #include <SDL.h>
+#include <assert.h>
 
 void
-player_init(player_t *player)
+player_init(player_t* player)
 {
   assert(player && "player is required");
   player->x = 0;
@@ -44,10 +45,11 @@ player_init(player_t *player)
   player->speed = 8;
 }
 
-void player_update(player_t     *player,
-                   controller_t *ctrl,
-                   int           screen_width,
-                   int           screen_height)
+void
+player_update(player_t* player,
+              controller_t* ctrl,
+              int screen_width,
+              int screen_height)
 {
   if (controller_is_up_pressed(ctrl) && player->y > 0) {
     player->y -= player->speed;
@@ -56,34 +58,29 @@ void player_update(player_t     *player,
 
   if (controller_is_down_pressed(ctrl) && player->y < screen_height) {
     player->y += player->speed;
-    player->y = player->y + player->height > screen_height 
-      ? screen_height - player->height 
-      : player->y;
+    player->y = player->y + player->height > screen_height
+                  ? screen_height - player->height
+                  : player->y;
   }
 
-  if (controller_is_left_pressed(ctrl) && player->x > 0)  {
+  if (controller_is_left_pressed(ctrl) && player->x > 0) {
     player->x -= player->speed;
-    player->x = player->x < 0 
-      ? 0 
-      : player->x;
+    player->x = player->x < 0 ? 0 : player->x;
   }
 
   if (controller_is_right_pressed(ctrl) && player->x < screen_width) {
     player->x += player->speed;
-    player->x = player->x + player->width > screen_width 
-      ? screen_width - player->width 
-      : player->x;
+    player->x = player->x + player->width > screen_width
+                  ? screen_width - player->width
+                  : player->x;
   }
 }
 
 void
-player_draw(player_t *player, SDL_Renderer *renderer)
+player_draw(player_t* player, SDL_Renderer* renderer)
 {
-  SDL_Rect rect = { 
-    .x = player->x, 
-    .y = player->y,
-    .w = player->width,
-    .h = player->height 
+  SDL_Rect rect = {
+    .x = player->x, .y = player->y, .w = player->width, .h = player->height
   };
 
   SDL_SetRenderDrawColor(renderer, 0, 0, 0xFF, 1);

--- a/src/player.h
+++ b/src/player.h
@@ -1,32 +1,33 @@
 /*
-* Copyright (c) 2021, Johnny Richard
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2021, Johnny Richard
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef PLAYER_H
 #define PLAYER_H
 
@@ -34,7 +35,8 @@
 
 #include <stdint.h>
 
-typedef struct player {
+typedef struct player
+{
   int16_t x;
   int16_t y;
   uint16_t width;
@@ -42,14 +44,17 @@ typedef struct player {
   uint16_t speed;
 } player_t;
 
-void player_init(player_t *player);
+void
+player_init(player_t* player);
 
 // FIXME: Find out a better way to provide screen w and h properties
-void player_update(player_t     *player,
-                   controller_t *ctrl,
-                   int           screen_width,
-                   int           screen_height);
+void
+player_update(player_t* player,
+              controller_t* ctrl,
+              int screen_width,
+              int screen_height);
 
-void player_draw(player_t *player, SDL_Renderer *renderer);
+void
+player_draw(player_t* player, SDL_Renderer* renderer);
 
 #endif /* PLAYER_H */

--- a/src/screen.c
+++ b/src/screen.c
@@ -1,40 +1,41 @@
 /*
-* Copyright (c) 2021, Fabio Maciel
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2021, Fabio Maciel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "screen.h"
 
-#include <stdint.h>
-#include <assert.h>
 #include <SDL.h>
+#include <assert.h>
+#include <stdint.h>
 
-const int SCREEN_WIDTH  = 640;
+const int SCREEN_WIDTH = 640;
 const int SCREEN_HEIGHT = 480;
 
 bool
@@ -45,26 +46,28 @@ screen_init(screen_t* screen)
   screen->width = SCREEN_WIDTH;
   screen->height = SCREEN_HEIGHT;
 
-  screen->window = SDL_CreateWindow(
-      "Blast Attack",
-      SDL_WINDOWPOS_UNDEFINED,
-      SDL_WINDOWPOS_UNDEFINED,
-      screen->width, screen->height,
-      SDL_WINDOW_RESIZABLE
-  );
+  screen->window = SDL_CreateWindow("Blast Attack",
+                                    SDL_WINDOWPOS_UNDEFINED,
+                                    SDL_WINDOWPOS_UNDEFINED,
+                                    screen->width,
+                                    screen->height,
+                                    SDL_WINDOW_RESIZABLE);
 
   if (screen->window == NULL) {
-    fprintf(stderr, "Window could not be created! SDL_Error: %s\n", SDL_GetError());
+    fprintf(
+      stderr, "Window could not be created! SDL_Error: %s\n", SDL_GetError());
     return false;
   }
 
-  screen->renderer = SDL_CreateRenderer(screen->window, -1, SDL_RENDERER_ACCELERATED);
+  screen->renderer =
+    SDL_CreateRenderer(screen->window, -1, SDL_RENDERER_ACCELERATED);
   if (screen->renderer == NULL) {
     fprintf(stderr, "Could not create renderer: %s\n", SDL_GetError());
     return false;
   }
 
-  if (SDL_RenderSetLogicalSize(screen->renderer, screen->width, screen->height) < 0) {
+  if (SDL_RenderSetLogicalSize(
+        screen->renderer, screen->width, screen->height) < 0) {
     fprintf(stderr, "Could not set logical size: %s\n", SDL_GetError());
     return false;
   }
@@ -73,14 +76,14 @@ screen_init(screen_t* screen)
 }
 
 void
-screen_reset(screen_t *screen)
+screen_reset(screen_t* screen)
 {
   SDL_SetRenderDrawColor(screen->renderer, 0, 0, 0, 1);
   SDL_RenderClear(screen->renderer);
 }
 
 void
-screen_destroy(screen_t *screen)
+screen_destroy(screen_t* screen)
 {
   SDL_DestroyRenderer(screen->renderer);
   SDL_DestroyWindow(screen->window);

--- a/src/screen.h
+++ b/src/screen.h
@@ -1,51 +1,56 @@
 /*
-* Copyright (c) 2021, Fabio Maciel
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2021, Fabio Maciel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef SCREEN_H
 #define SCREEN_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <SDL.h>
 
-typedef struct screen {
+typedef struct screen
+{
   uint16_t width;
   uint16_t height;
   SDL_Renderer* renderer;
   SDL_Window* window;
 } screen_t;
 
-bool screen_init(screen_t *screen);
+bool
+screen_init(screen_t* screen);
 
-void screen_reset(screen_t *screen);
+void
+screen_reset(screen_t* screen);
 
-void screen_destroy(screen_t *screen);
+void
+screen_destroy(screen_t* screen);
 
 #endif /* SCREEN_H */

--- a/test/controller-test.c
+++ b/test/controller-test.c
@@ -5,8 +5,8 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
@@ -18,14 +18,15 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
@@ -33,87 +34,110 @@
 #include <munit/munit.h>
 
 static SDL_Event
-an_event(SDL_EventType type, SDL_KeyCode keycode) {
-    SDL_Event event;
-    event.type = type;
-    event.key.keysym.sym = keycode;
-    return event;
+an_event(SDL_EventType type, SDL_KeyCode keycode)
+{
+  SDL_Event event;
+  event.type = type;
+  event.key.keysym.sym = keycode;
+  return event;
 }
 
 static MunitResult
 press_and_release_up(const MunitParameter params[], void* fixture)
 {
-    controller_t ctrl = {0};
+  controller_t ctrl = { 0 };
 
-    SDL_Event event = an_event(SDL_KEYDOWN, SDLK_UP);
-    controller_update(&ctrl, &event);
-    assert_true(controller_is_up_pressed(&ctrl));
+  SDL_Event event = an_event(SDL_KEYDOWN, SDLK_UP);
+  controller_update(&ctrl, &event);
+  assert_true(controller_is_up_pressed(&ctrl));
 
-    event = an_event(SDL_KEYUP, SDLK_UP);
-    controller_update(&ctrl, &event);
-    assert_false(controller_is_up_pressed(&ctrl));
-    return MUNIT_OK;
+  event = an_event(SDL_KEYUP, SDLK_UP);
+  controller_update(&ctrl, &event);
+  assert_false(controller_is_up_pressed(&ctrl));
+  return MUNIT_OK;
 }
 
 static MunitResult
 press_and_release_down(const MunitParameter params[], void* fixture)
 {
-    controller_t ctrl = {0};
+  controller_t ctrl = { 0 };
 
-    SDL_Event event = an_event(SDL_KEYDOWN, SDLK_DOWN);
-    controller_update(&ctrl, &event);
-    assert_true(controller_is_down_pressed(&ctrl));
+  SDL_Event event = an_event(SDL_KEYDOWN, SDLK_DOWN);
+  controller_update(&ctrl, &event);
+  assert_true(controller_is_down_pressed(&ctrl));
 
-    event = an_event(SDL_KEYUP, SDLK_DOWN);
-    controller_update(&ctrl, &event);
-    assert_false(controller_is_down_pressed(&ctrl));
-    return MUNIT_OK;
+  event = an_event(SDL_KEYUP, SDLK_DOWN);
+  controller_update(&ctrl, &event);
+  assert_false(controller_is_down_pressed(&ctrl));
+  return MUNIT_OK;
 }
 
 static MunitResult
 press_and_release_right(const MunitParameter params[], void* fixture)
 {
-    controller_t ctrl = {0};
+  controller_t ctrl = { 0 };
 
-    SDL_Event event = an_event(SDL_KEYDOWN, SDLK_RIGHT);
-    controller_update(&ctrl, &event);
-    assert_true(controller_is_right_pressed(&ctrl));
+  SDL_Event event = an_event(SDL_KEYDOWN, SDLK_RIGHT);
+  controller_update(&ctrl, &event);
+  assert_true(controller_is_right_pressed(&ctrl));
 
-    event = an_event(SDL_KEYUP, SDLK_RIGHT);
-    controller_update(&ctrl, &event);
-    assert_false(controller_is_right_pressed(&ctrl));
-    return MUNIT_OK;
+  event = an_event(SDL_KEYUP, SDLK_RIGHT);
+  controller_update(&ctrl, &event);
+  assert_false(controller_is_right_pressed(&ctrl));
+  return MUNIT_OK;
 }
 
 static MunitResult
 press_and_release_left(const MunitParameter params[], void* fixture)
 {
-    controller_t ctrl = {0};
+  controller_t ctrl = { 0 };
 
-    SDL_Event event = an_event(SDL_KEYDOWN, SDLK_LEFT);
-    controller_update(&ctrl, &event);
-    assert_true(controller_is_left_pressed(&ctrl));
+  SDL_Event event = an_event(SDL_KEYDOWN, SDLK_LEFT);
+  controller_update(&ctrl, &event);
+  assert_true(controller_is_left_pressed(&ctrl));
 
-    event = an_event(SDL_KEYUP, SDLK_LEFT);
-    controller_update(&ctrl, &event);
-    assert_false(controller_is_left_pressed(&ctrl));
-    return MUNIT_OK;
+  event = an_event(SDL_KEYUP, SDLK_LEFT);
+  controller_update(&ctrl, &event);
+  assert_false(controller_is_left_pressed(&ctrl));
+  return MUNIT_OK;
 }
 
 MunitTest tests[] = {
-    { "/press_and_release_up",    press_and_release_up,    NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
-    { "/press_and_release_down",  press_and_release_down,  NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
-    { "/press_and_release_right", press_and_release_right, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
-    { "/press_and_release_left",  press_and_release_left,  NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
-    { NULL,                       NULL,                    NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+  { "/press_and_release_up",
+    press_and_release_up,
+    NULL,
+    NULL,
+    MUNIT_TEST_OPTION_NONE,
+    NULL },
+  { "/press_and_release_down",
+    press_and_release_down,
+    NULL,
+    NULL,
+    MUNIT_TEST_OPTION_NONE,
+    NULL },
+  { "/press_and_release_right",
+    press_and_release_right,
+    NULL,
+    NULL,
+    MUNIT_TEST_OPTION_NONE,
+    NULL },
+  { "/press_and_release_left",
+    press_and_release_left,
+    NULL,
+    NULL,
+    MUNIT_TEST_OPTION_NONE,
+    NULL },
+  { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };
 
-static const MunitSuite suite = {
-    "/controller", tests, NULL, 1, MUNIT_TEST_OPTION_NONE
-};
+static const MunitSuite suite = { "/controller",
+                                  tests,
+                                  NULL,
+                                  1,
+                                  MUNIT_TEST_OPTION_NONE };
 
 int
-main(int argc, char *argv[])
+main(int argc, char* argv[])
 {
-    return munit_suite_main(&suite, NULL, argc, argv);
+  return munit_suite_main(&suite, NULL, argc, argv);
 }


### PR DESCRIPTION
This patchset introduce the following changes:

- Add clang-format based on Mozilla style code
- styling: Reformat the entire code base based on clang-format
- styling: Add target check on Makefile for checkstyle


NOTE:

- This Pull Request is easier to review by commit.

UPDATES:

V2:
- [CI: Add checkstyle checking to workflow](https://github.com/fabiomaciel/blast-attack/pull/10/commits/bf7e414b4ffce5c606c954843c0804cf9e0293f0)

